### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Fly Deploy
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Lands-Horizon-Corp/e-coop-server/security/code-scanning/5](https://github.com/Lands-Horizon-Corp/e-coop-server/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. This can be done at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). Since there is only one job in this workflow, either location is acceptable, but adding it at the workflow root is more concise and future-proof. The block should specify `contents: read`, which is the minimal permission required for checking out code. No additional imports or definitions are needed; simply insert the `permissions` block after the `name` field and before the `on` field in `.github/workflows/main.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
